### PR TITLE
Pin pyannote.audio version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Cite the published paper if you used aTrain for your research: [Take the aTrain.
 ## Becoming a developer
 Please refer to [Developer wiki page](https://github.com/JuergenFleiss/aTrain/wiki/Development:-Branching,-contributing-and-releases) for the details on how to contribute to the project and other useful information for developers.
 
+Note: The speaker detection feature relies on `pyannote.audio` version `3.3.2`. This dependency is pinned in `pyproject.toml` to ensure consistent builds.
+
 
 ## About aTrain
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "flair; sys_platform == 'linux'",
   "spacy; sys_platform == 'linux'",
   "PyGObject==3.50.0; sys_platform == 'linux'",                              #fix depency according to https://github.com/beeware/toga/issues/3143
+  "pyannote.audio==3.3.2",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Summary
- keep pyannote.audio pinned in pyproject.toml
- document pinned dependency in README

## Testing
- `pip show pyannote.audio | head -n 3`
- `pip show atrain-core | head -n 3` *(fails: package not found)*
- `python -m py_compile aTrain/__init__.py aTrain/app.py build.py`


------
https://chatgpt.com/codex/tasks/task_e_68413d8f463083318b0749c30f5fa074